### PR TITLE
Fix error when hook is unused

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ export default {
             computed: {
                 extensions ()  {
                     // console.log(`hook ${this.hook}: `, hookRegistry[this.hook])
+                    if (hookRegistry[this.hook] === undefined) {
+                      return null
+                    }
                     return hookRegistry[this.hook].sort((obj1, obj2) => {
                       return obj1.weight - obj2.weight
                     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-extensions",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-extensions",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "author": "Christian González <christian.gonzalez@nerdocs.at>",
   "scripts": {


### PR DESCRIPTION
This commit adds a undefined check before trying to sort the hook's components, returning "null" when hook is empty/unused.